### PR TITLE
Strip version number from auth_url

### DIFF
--- a/tests.py
+++ b/tests.py
@@ -187,5 +187,10 @@ password = env['OS_PASSWORD']
 auth_url = env['OS_AUTH_URL']
 project = env['OS_TENANT_NAME']
 
+# many auth_urls include the version. this will strip the version
+# declaration from the auth_url
+if 'v2.0' in auth_url:
+    auth_url = '/'.join(auth_url.split('v2.0')[:-1])
+
 test = DHCTest(username, password, auth_url, project)
 test.test_all()


### PR DESCRIPTION
Many auth_urls include the version (i.e. http://foo.com/v2.0).  libcloud
does not like this.  This patch will check if v2.0 is in the url and
strip it out.
